### PR TITLE
DEG-190: Site studio integration with DST.

### DIFF
--- a/drush.services.yml
+++ b/drush.services.yml
@@ -66,3 +66,10 @@ services:
       - '@dst_entity_generate.general_api'
     tags:
       - { name: drush.command }
+  dst_entity_generate.commands.sitestudio_settings:
+    class: Drupal\dst_entity_generate\Commands\SiteStudioSettings
+    arguments:
+      - '@entity_type.manager'
+      - '@uuid'
+    tags:
+      - { name: drush.command }

--- a/src/Commands/GenerateAll.php
+++ b/src/Commands/GenerateAll.php
@@ -49,7 +49,8 @@ class GenerateAll extends BaseEntityGenerate {
       'deg:media',
       'deg:p',
       'deg:ct',
-      'deg:cbt'
+      'deg:cbt',
+      'deg:ss',
     ];
     if ($options['update']) {
       $commands = array_map(function($command) { return $command . ' --update'; }, $commands);

--- a/src/Commands/SiteStudioSettings.php
+++ b/src/Commands/SiteStudioSettings.php
@@ -1,0 +1,225 @@
+<?php
+
+namespace Drupal\dst_entity_generate\Commands;
+
+use Drupal\Component\Plugin\Exception\InvalidPluginDefinitionException;
+use Drupal\Component\Plugin\Exception\PluginNotFoundException;
+use Drupal\Core\Entity\EntityInterface;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\dst_entity_generate\BaseEntityGenerate;
+use Drupal\dst_entity_generate\DstegConstants;
+use Drupal\Component\Uuid\UuidInterface;
+
+/**
+ * Providees functionality for creating Cohesion font stack from DST sheet.
+ *
+ * @package Drupal\dst_entity_generate\Commands
+ */
+class SiteStudioSettings extends BaseEntityGenerate {
+
+  /**
+   * {@inheritDoc}
+   */
+  protected $dstEntityName = 'site_studio_settings';
+
+  /**
+   * Array of all dependent modules.
+   *
+   * @var array
+   */
+  protected $dependentModules = ['cohesion', 'cohesion_website_settings'];
+
+  /**
+   * Entity Type manager service.
+   *
+   * @var \Drupal\Core\Entity\EntityTypeManagerInterface
+   */
+  protected $entityTypeManager;
+
+  /**
+   * A service for generating UUIDs.
+   *
+   * @var \Drupal\Component\Uuid\UuidInterface
+   */
+  protected $uuid;
+
+  /**
+   * List of required fields to create entity.
+   *
+   * @var array
+   */
+  protected $requiredFields = ['label', 'machine_name'];
+
+  /**
+   * Content type generator constructor.
+   *
+   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entityTypeManager
+   *   Entity Type manager.
+   * @param \Drupal\Component\Uuid\UuidInterface $uuid
+   *   A service for generating UUIDs.
+   */
+  public function __construct(EntityTypeManagerInterface $entityTypeManager, UuidInterface $uuid) {
+    $this->entityTypeManager = $entityTypeManager;
+    $this->uuid = $uuid;
+  }
+
+  /**
+   * Generate all the Drupal content types from DEG sheet.
+   *
+   * @command deg:generate:site-studio
+   * @aliases deg:ss $type
+   * @usage drush deg:ss color
+   *   Generates site studio fonts if not present.
+   * @usage drush deg:ss --update
+   *   Generate site studio fonts if not present also updates existing.
+   * @option update Updates existing entity types and creates new if not present.
+   */
+  public function generateSiteStudioSettings($options = ['update' => FALSE, 'type' => NULL]) {
+    $this->io()->success('Generating site studio settings.');
+    $this->updateMode = $options['update'];
+    $mode = 'create';
+    if ($this->updateMode) {
+      $mode = 'update';
+    }
+    $data = $this->getDataFromSheet(DstegConstants::SITE_STUDIO_SETTINGS);
+    // Site studio settings generated from DST sheet.
+    $settings = $this->getSiteStudioData($data, $options['type']);
+    foreach ($settings as $key => $value) {
+      $type = $value['type'];
+      $setting = $value['entity']['id'];
+      $entity_type = ($type === 'Font') ? 'cohesion_font_stack' : 'cohesion_color';
+      $entity = $this->entityTypeManager->getStorage($entity_type)->load($setting);
+      if (!empty($entity)) {
+        if ($this->updateMode && $data[$key][$this->implementationFlagColumn] === $this->updateFlag) {
+          $this->updateEntityType($entity, $value['entity']);
+          $this->io()->success($type . ' ' . $setting .  " updated.");
+          continue;
+        }
+        $this->io()->warning($type . ' ' . $setting . " Already exists. Skipping creation.");
+        continue;
+      }
+      $status = $this->entityTypeManager->getStorage($entity_type)->create($value['entity'])->save();
+      if ($status === SAVED_NEW) {
+        $this->io()->success($type . ' ' . $setting .  " is successfully created.");
+      }
+    }
+  }
+
+  /**
+   * Get data needed for site studio entity.
+   *
+   * @param array $data
+   *   Array of Data.
+   *
+   * @return array|null
+   *   Font stack data.
+   */
+  private function getSiteStudioData(array $data, $param) {
+    $site_studio_data = [];
+    foreach ($data as $item) {
+      // To allow existing entity update.
+      if (!$this->validateMachineName($item['machine_name'])) {
+        continue;
+      }
+      // Type value will distinguish between the cohesion entities.
+      // Command with param -> type = param.
+      // Command with no param -> type value from sheet data to be considered.
+      $type = $param ?: strtolower($item['type']);
+      switch ($type) {
+        case 'font':
+          // Prepare json values only if item has font data.
+          $json_values = ($item['type'] === 'Font') ? $this->getFontJsonValues($item) : [];
+
+          break;
+        case 'color':
+          // Prepare json values only if item has color data.
+          $json_values = ($item['type'] === 'Color') ? $this->getColorJsonValues($item) : [];
+
+          break;
+      }
+      // Site studio entity configuration.
+      if (!empty($json_values)) {
+        $entity = [
+          'langcode' => 'en',
+          'status' => true,
+          'label' => $item['label'],
+          'id' => $item['machine_name'],
+          'uuid' => $this->uuid->generate(),
+          'json_values' => json_encode($json_values),
+          'json_mapper' => '{}',
+          'modified' => true,
+          'selectable' => true,
+          'locked' => false,
+          'weight' => 0,
+        ];
+        $site_studio_data[] = [
+          'entity' => $entity,
+          'type' => $item['type'],
+        ];
+      }
+    }
+
+    return $site_studio_data;
+  }
+
+  /**
+   * Prepares json value for cohesion font stack.
+   *
+   * @param $item
+   *  The data coming from DST sheet.
+   * @return array
+   *  Returns json_values.
+   */
+  protected function getFontJsonValues($item): array {
+    return [
+      'name' => $item['label'],
+      'fontStack' => $item['metadata'],
+      'variable' => '$coh-' . $item['machine_name'],
+      'uid' => $item['machine_name'],
+      'class' => '.coh-' . $item['machine_name'],
+    ];
+
+  }
+
+  /**
+   * Prepares json value for cohesion color.
+   *
+   * @param $item
+   *  The data coming from DST sheet.
+   * @return array
+   *  Returns json_values.
+   */
+  protected function getColorJsonValues($item): array {
+    $tags = [];
+    $rgba_color = $this->hex2rgba($item['metadata'], 1);
+    if (array_key_exists('tag', $item) && $item['tag']) {
+      $tag = [$item['tag']];
+    } else {
+      $tag = [];
+    }
+    return [
+      'link' => true,
+      'value' => [
+        'value' => [
+          'hex' => $item['metadata'],
+          'rgba' => $rgba_color,
+        ],
+      ],
+      'uid' => $item['machine_name'],
+      'name' => $item['label'],
+      'class' => '.coh-color-' . $item['machine_name'],
+    ];
+  }
+
+  /**
+   * Converts hex code to rgba.
+   *
+   * @param $hex
+   *  Hex code coming from DST sheet.
+   * @param $alpha
+   * @return string
+   */
+  protected function hex2rgba($hex, $alpha): string {
+    return 'RGBA Value';
+  }
+}

--- a/src/Commands/SiteStudioSettings.php
+++ b/src/Commands/SiteStudioSettings.php
@@ -257,34 +257,30 @@ class SiteStudioSettings extends BaseEntityGenerate {
    */
   public function hex2rgba($color, $opacity = FALSE): string {
     $default_color = 'rgb(0,0,0)';
-    // Return default color if no color provided.
-    if (empty($color)) {
-      return $default_color;
-    }
-
-    // Ignore "#" if provided.
-    $color = ($color[0] === '#') ? substr($color, 1) : $color;
-
-    // Check if color has 6 or 3 characters, get values.
-    if (strlen($color) === 6) {
-      $hex = [$color[0] . $color[1], $color[2] . $color[3], $color[4] . $color[5]];
-    }
-    elseif (strlen($color) === 3) {
-      $hex = [$color[0] . $color[0], $color[1] . $color[1], $color[2] . $color[2]];
-    }
-
-    // Convert hex values to rgb values.
-    $rgb = array_map('hexdec', $hex);
-
-    // Check if opacity is set(rgba or rgb)
-    if ($opacity) {
-      if (abs($opacity) > 1) {
-        $opacity = 1.0;
+    if (!empty($color)) {
+      // Ignore "#" if provided.
+      $color = ($color[0] === '#') ? substr($color, 1) : $color;
+      // Check if color has 6 or 3 characters, get values.
+      if (strlen($color) === 6) {
+        $hex = [$color[0] . $color[1], $color[2] . $color[3], $color[4] . $color[5]];
       }
-      $output = 'rgba(' . implode(",", $rgb) . ',' . $opacity . ')';
+      elseif (strlen($color) === 3) {
+        $hex = [$color[0] . $color[0], $color[1] . $color[1], $color[2] . $color[2]];
+      }
+
+      // Convert hex values to rgb values.
+      $rgb = array_map('hexdec', $hex);
+      // Check if opacity is set(rgba or rgb)
+      if ($opacity) {
+        $opacity = (abs($opacity) > 1) ? 1.0 : $opacity;
+        $output = 'rgba(' . implode(",", $rgb) . ',' . $opacity . ')';
+      }
+      else {
+        $output = 'rgb(' . implode(",", $rgb) . ')';
+      }
     }
     else {
-      $output = 'rgb(' . implode(",", $rgb) . ')';
+      $output = $default_color;
     }
 
     // Return rgb(a) color string.

--- a/src/Commands/SiteStudioSettings.php
+++ b/src/Commands/SiteStudioSettings.php
@@ -263,19 +263,14 @@ class SiteStudioSettings extends BaseEntityGenerate {
     }
 
     // Ignore "#" if provided.
-    if ($color[0] == '#') {
-      $color = substr($color, 1);
-    }
+    $color = ($color[0] === '#') ? substr($color, 1) : $color;
 
     // Check if color has 6 or 3 characters, get values.
-    if (strlen($color) == 6) {
+    if (strlen($color) === 6) {
       $hex = [$color[0] . $color[1], $color[2] . $color[3], $color[4] . $color[5]];
     }
-    elseif (strlen($color) == 3) {
+    elseif (strlen($color) === 3) {
       $hex = [$color[0] . $color[0], $color[1] . $color[1], $color[2] . $color[2]];
-    }
-    else {
-      return $default_color;
     }
 
     // Convert hex values to rgb values.

--- a/src/DstegConstants.php
+++ b/src/DstegConstants.php
@@ -294,11 +294,15 @@ final class DstegConstants {
     ],
     'cohesion_font_stack' => [
       'label',
-      'json_values'
+      'json_values',
+    ],
+    'cohesion_font_library' => [
+      'label',
+      'json_values',
     ],
     'cohesion_color' => [
       'label',
-      'json_values'
+      'json_values',
     ],
   ];
 

--- a/src/DstegConstants.php
+++ b/src/DstegConstants.php
@@ -26,6 +26,7 @@ final class DstegConstants {
   const IMAGE_EFFECTS = 'Image effects';
   const OVERVIEW = 'Overview';
   const SKIP_ENTITY_MESSAGE = 'Skipping: @entity entity sync is disabled.';
+  const SITE_STUDIO_SETTINGS = 'Site Studio Settings';
   /**
    * Variable FIELD_TYPES is used to hold meta data about field types.
    *
@@ -291,6 +292,14 @@ final class DstegConstants {
     'workflow' => [
       'label',
     ],
+    'cohesion_font_stack' => [
+      'label',
+      'json_values'
+    ],
+    'cohesion_color' => [
+      'label',
+      'json_values'
+    ],
   ];
 
   const ENTITY_TYPE_MODULE_DEPENDENCIES = [
@@ -303,6 +312,7 @@ final class DstegConstants {
     DstegConstants::MENUS => ['menu_ui'],
     DstegConstants::VOCABULARIES => ['taxonomy'],
     DstegConstants::WORKFLOWS => ['workflows', 'content_moderation'],
+    DstegConstants::SITE_STUDIO_SETTINGS => ['cohesion', 'cohesion_website_settings'],
   ];
 
   const FIELD_FORM_WIDGET = [


### PR DESCRIPTION
A similar PR may already be submitted!
Please search among the [Pull request](https://github.com/acquia-pso/dst-entity-generate/pulls) before creating one.

Thanks for submitting a pull request! Please provide enough information so that others can review your pull request:

For more information, see the [CONTRIBUTING guide](https://github.com/acquia-pso/dst-entity-generate/blob/master/CONTRIBUTING.md).


**Summary**
This PR contains code block to integrate site studio website settings with DEG module.

This PR fixes/implements the following features:

* Integration with site studio color, font stack and font library.
* Commands to generate/update all entities
```
drush deg:ss 
drush deg:ss  —update
```

- Commands to generate specific entity
```
drush deg:ss  —type color
drush deg:ss  —type font_stack
drush deg:ss  —type font_library
```

- Commands to update specific entity
```
drush deg:ss  —update —type color
drush deg:ss  —update —type font_stack
drush deg:ss  —update —type 
```
The reference DST sheet:

<img width="1611" alt="image" src="https://github.com/acquia-pso/dst-entity-generate/assets/92932445/168090a5-d3a0-4b39-bb70-5c38a891bd3b">

